### PR TITLE
refactor: handle REDIS_URL as base64 encoded object string

### DIFF
--- a/src/config/redis.ts
+++ b/src/config/redis.ts
@@ -1,10 +1,31 @@
 import { RedisOptions } from 'ioredis';
 
 export const createRedisConfig = (): any => {
-  const config: RedisOptions = {};
+  let config: RedisOptions = {};
 
-  if (process.env.REDIS_URL) {
-    return process.env.REDIS_URL;
+  const url = process.env.REDIS_URL ?? null;
+  if (url) {
+    if (!url.startsWith('ioredis://')) {
+      // For REDIS_URL you can either specify an ioredis compatible url like this
+      // REDIS_URL=redis://user:password@host:port/db
+      return process.env.REDIS_URL;
+    } else {
+      try {
+        // Redis connection args can be provided as a base64 encoded JSON object
+        // instead of manually passing any of the many individual options one by one.
+        // ie, Redis Sentinel connection object: {"sentinels":[{"host":"sentinel-0","port":26379},{"host":"sentinel-1","port":26379}],"name":"mymaster"}
+        // to base64 variable:
+        // REDIS_URL=ioredis://eyJzZW50aW5lbHMiOlt7Imhvc3QiOiJzZW50aW5lbC0wIiwicG9ydCI6MjYzNzl9LHsiaG9zdCI6InNlbnRpbmVsLTEiLCJwb3J0IjoyNjM3OX1dLCJuYW1lIjoibXltYXN0ZXIifQ==
+        const decodedString = Buffer.from(
+          process.env.REDIS_SENTINEL_URL.slice(10),
+          'base64'
+        ).toString();
+
+        config = JSON.parse(decodedString);
+      } catch (error) {
+        throw new Error(`Failed to decode redis adapter options: ${error}`);
+      }
+    }
   } else if (process.env.REDIS_PORT && process.env.REDIS_HOST) {
     config.host = process.env.REDIS_HOST;
     config.port = Number(process.env.REDIS_PORT);

--- a/src/service/BullQueue.ts
+++ b/src/service/BullQueue.ts
@@ -2,6 +2,7 @@ import { BULL_QUEUE } from '../utils/enums';
 import { Queue, Worker } from 'bullmq';
 import { calculateWebcalAlarms } from '../jobs/queueJobs/calculateWebcalAlarmsJob';
 import { createRedisConfig } from '../config/redis';
+import { isString } from 'lodash';
 import { processEmailEventJob } from '../jobs/queueJobs/processEmailEventJob';
 import { sendEmailQueueJob } from '../jobs/queueJobs/sendEmailQueueJob';
 import { syncCalDavQueueJob } from '../jobs/queueJobs/syncCalDavQueueJob';
@@ -24,14 +25,8 @@ export let cardDavBullQueue;
 const getConnection = () => {
   const config = createRedisConfig();
 
-  if (config.host && config.port) {
-    return {
-      host: config.host,
-      port: config.port,
-    };
-  } else {
+  if (isString(config)) {
     const url = new URL(config);
-
     if (url) {
       return {
         host: url.hostname,
@@ -40,6 +35,8 @@ const getConnection = () => {
         password: url.password,
       };
     }
+  } else {
+    return config;
   }
 };
 


### PR DESCRIPTION
If a setup required a more verbose Redis connection object, ie., a Redis Sentinel cluster:
```
{"sentinels":[{"host":"sentinel-0","port":26379},{"host":"sentinel-1","port":26379}],"name":"mymaster"}
```
A base64 encoded string can be passed in as the REDIS_URL env var instead of manually accounting for each and every possible option, (my current needs has 3 sentinels as well as password and db).
```
REDIS_URL=ioredis://eyJzZW50aW5lbHMiOlt7Imhvc3QiOiJzZW50aW5lbC0wIiwicG9ydCI6MjYzNzl9LHsiaG9zdCI6InNlbnRpbmVsLTEiLCJwb3J0IjoyNjM3OX1dLCJuYW1lIjoibXltYXN0ZXIifQ==
```

Alternatively, the current REDIS_URL can still be specified as an ioredis compatible url string like this:
```
REDIS_URL=redis://user:password@host:port/db
```
