### PR TITLE
last-modified in ical should be optional

### DIFF
--- a/src/data/entity/WebcalEventEntity.ts
+++ b/src/data/entity/WebcalEventEntity.ts
@@ -141,7 +141,7 @@ export default class WebcalEventEntity {
       })) as any;
       this.description = data.description;
       this.location = data.location;
-      this.updatedAt = DateTime.fromISO(data.lastModified?.value)
+      this.updatedAt = (!data.lastModified?.value ? DateTime.now() : DateTime.fromISO(data.lastModified?.value))
         .toUTC()
         .toJSDate();
       this.sequence = Number(data.sequence);


### PR DESCRIPTION
Per specification https://icalendar.org/iCalendar-RFC-5545/3-6-1-event-component.html the last-modified attribute should be optional, however bloben fails to import ical feeds without last-modified field. This PR sets the updatedAt property to current time if the last-modified was not found.